### PR TITLE
Change autobuild to push to ghcr.io instead of hub.ncsa.illinois.edu

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           images: |
             ghcr.io/moleculemaker/molli
+            ghcr.io/SEDenmarkLab/molli
           tags: |
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -54,7 +55,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Login to NCSA Harbor
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Problem
We are seeing mysterious failures pushing to NCSA Harbor

## Approach
* Push to [ghcr.io](https://github.com/features/packages) instead
* Push during PRs as well (this allows us to test without merging)
* Include `ncsa-workflow` in the list of watched branches
    * Pushing to a branch will push the image as `ghcr.io/moleculemaker/molli:<branch-name>`
    * Pushing to default branch (main) will also push the same image as `ghcr.io/moleculemaker/molli:latest`
        * `latest` is the default image tag that is pulled when running `docker pull ghcr.io/moleculemaker/molli`
* TODO: Remove old `NCSAHARBOR_*` Secrets in GitHub org and create new Secrets for `GITHUB_*`

## How to Test
Just wait, eventually a green checkmark should appear on this PR :+1: