### PR TITLE
fix #108: ConformerEnsemble init with ensemble

### DIFF
--- a/molli/chem/ensemble.py
+++ b/molli/chem/ensemble.py
@@ -90,7 +90,7 @@ class ConformerEnsemble(Connectivity):
     ):
         # TODO: revise the constructor
 
-        if isinstance(other, list) and isinstance(other[0], Structure):
+        if isinstance(other, list) and all(isinstance(o, Structure) for o in other):
             super().__init__(
                 other[0],
                 name=other[0].name,
@@ -116,21 +116,16 @@ class ConformerEnsemble(Connectivity):
                 **kwds,
             )
             self._coords = np.full((n_conformers, self.n_atoms, 3), np.nan)
-            self._atomic_charges = np.zeros(
-                (
-                    n_conformers,
-                    self.n_atoms,
-                )
-            )
+            self._atomic_charges = np.zeros((n_conformers, self.n_atoms))
             self._weights = np.ones((n_conformers,))
 
         if isinstance(other, ConformerEnsemble):
-            self.atomic_charges = atomic_charges
-            self.coords = other.coords
-            self.weights = other.weights
-        else:
-            if coords is not None:
-                self.coords = coords
+            self._atomic_charges = np.array(other.atomic_charges)
+            self._coords = np.array(other.coords)
+            self._weights = np.array(other.weights)
+
+        if coords is not None:
+            self.coords = coords
 
         if atomic_charges is not None:
             self.atomic_charges = atomic_charges
@@ -225,11 +220,11 @@ class ConformerEnsemble(Connectivity):
             )
 
         return res
-    
+
     def dump_mol2(self, stream: StringIO = None):
         if stream is None:
             stream = StringIO()
-            
+
         for conf in self:
             conf.dump_mol2(stream)
 
@@ -240,7 +235,7 @@ class ConformerEnsemble(Connectivity):
         stream = StringIO()
         self.dump_mol2(stream)
         return stream.getvalue()
-    
+
     @property
     def n_conformers(self):
         return self._coords.shape[0]

--- a/molli_test/test_conformer_ensemble.py
+++ b/molli_test/test_conformer_ensemble.py
@@ -51,9 +51,21 @@ class ConformerEnsembleTC(ut.TestCase):
         self.assertEqual(ens2.n_atoms, 3)
         self.assertTupleEqual(ens2.coords.shape, (5, 3, 3))
 
-    def test_init_with_other_ensemble(self):
+    def test_init_with_other_empty_ensemble(self):
         "Tests initializing ConformerEnsemble from the other instance of ConformerEnsemble class"
         ens = ml.ConformerEnsemble(["O", "H", "H"])
+        new_ens = ml.ConformerEnsemble(ens, name="new_ens")
+
+        self.assertEqual(new_ens.n_conformers, ens.n_conformers)
+        self.assertEqual(new_ens.n_atoms, ens.n_atoms)
+        self.assertEqual(new_ens.name, "new_ens")
+        self.assertTupleEqual(new_ens.coords.shape, ens.coords.shape)
+        self.assertTupleEqual(new_ens.weights.shape, ens.weights.shape)
+        self.assertTupleEqual(new_ens.atomic_charges.shape, ens.atomic_charges.shape)
+
+    def test_init_with_other_ensemble(self):
+        "Tests initializing ConformerEnsemble from the other instance of ConformerEnsemble class"
+        ens = ml.ConformerEnsemble.load_mol2(ml.files.pentane_confs_mol2)
         new_ens = ml.ConformerEnsemble(ens, name="new_ens")
 
         self.assertEqual(new_ens.n_conformers, ens.n_conformers)


### PR DESCRIPTION
Fixed #108 and added a corresponding unit test. The default behavior for initialization of `ConformerEnsemble` with another instance of that class should be effectively the same as copying an object.