### PR TITLE
Hot Fix to Bonds and Substructure

### DIFF
--- a/molli/chem/bond.py
+++ b/molli/chem/bond.py
@@ -145,12 +145,12 @@ class Bond:
 
     btype: BondType = attrs.field(
         default=BondType.Single,
-        repr=lambda x: x.name,
+        repr=False,
     )
 
     stereo: BondStereo = attrs.field(
         default=BondStereo.Unknown,
-        repr=lambda x: x.name,
+        repr=False,
     )
 
     f_order: float = attrs.field(

--- a/molli/chem/bond.py
+++ b/molli/chem/bond.py
@@ -145,12 +145,12 @@ class Bond:
 
     btype: BondType = attrs.field(
         default=BondType.Single,
-        repr=False,
+        repr=lambda x: x.name if hasattr(x, 'name') else x,
     )
 
     stereo: BondStereo = attrs.field(
         default=BondStereo.Unknown,
-        repr=False,
+        repr=lambda x: x.name if hasattr(x, 'name') else x,
     )
 
     f_order: float = attrs.field(

--- a/molli/chem/structure.py
+++ b/molli/chem/structure.py
@@ -1009,6 +1009,7 @@ class Substructure(Structure):
         self._parent = parent
         self._atoms = [parent.get_atom(a) for a in atoms]
         self._bonds = []
+        self.attrib = parent.attrib.copy()
 
         for b in parent.bonds:
             if b.a1 in self.atoms and b.a2 in self.atoms:

--- a/molli_test/test_chem_structure.py
+++ b/molli_test/test_chem_structure.py
@@ -120,6 +120,21 @@ class StructureTC(ut.TestCase):
 
         np.testing.assert_allclose(s1_coord, sub_coord)
 
+        pro1 = ml.Promolecule(s1)
+        pro1.atoms
+
+        con1 = ml.Connectivity(s1)
+        con1.atoms
+        con1.bonds
+
+        struct1 = ml.Structure(s1)
+        struct1.atoms
+        struct1.bonds
+
+        m1 = ml.Molecule(s1)
+        m1.atoms
+        m1.bonds
+
     def test_del_atom(self):
         s1 = ml.Structure.load_mol2(ml.files.dendrobine_mol2)
         s1.del_atom(0)


### PR DESCRIPTION
- Fixed representation error on bonds
- Added `attrib` property to `ml.Substructure` and additional UT

Passed UT