### PR TITLE
RDKit x Molli Update

### DIFF
--- a/.github/workflows/mamba-build-test.yml
+++ b/.github/workflows/mamba-build-test.yml
@@ -20,6 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up MSVC (Windows only)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Delete Incorrect Link from Path
+        if: matrix.os == 'windows-latest'
+        run: rm /usr/bin/link.exe
+        
       - name: Install micromamba
         uses: mamba-org/setup-micromamba@v1
         env:

--- a/.github/workflows/mamba-build-test.yml
+++ b/.github/workflows/mamba-build-test.yml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Install conda build and upload dependencies
         run: |
-          conda install boa
+          conda install boa;
+          conda install conda-verify;
 
       - name: Build package
         env:

--- a/molli/external/__init__.py
+++ b/molli/external/__init__.py
@@ -6,5 +6,5 @@ class RDKitException(Exception):
     "Raised when RDKit fails during Molecule Creation"
     pass
 
-class RDKitKekulizationException(Exception):
+class RDKitKekulizationException(RDKitException):
     "Raised when RDKit fails to kekulize during Molecule Creation"

--- a/molli/external/__init__.py
+++ b/molli/external/__init__.py
@@ -1,3 +1,10 @@
-# This file is left empty on purpose. It serves to indicate a valid submodule.
+# This file can be left empty. It serves to indicate a valid submodule.
 # The respective sub-submodules are meant to be loaded "lazily" so as not to invoke
 # unnecessary dependencies before they might become necessary.
+
+class RDKitException(Exception):
+    "Raised when RDKit fails during Molecule Creation"
+    pass
+
+class RDKitKekulizationException(Exception):
+    "Raised when RDKit fails to kekulize during Molecule Creation"

--- a/molli/external/rdkit.py
+++ b/molli/external/rdkit.py
@@ -53,13 +53,7 @@ from rdkit.Chem.Draw import IPythonConsole
 from openbabel.pybel import readstring
 from rdkit.Chem import MolToMolBlock
 from molli.external.openbabel import from_obmol
-
-class RDKitException(Exception):
-    "Raised when RDKit fails during Molecule Creation"
-    pass
-
-class RDKitKekulizationException(Exception):
-    "Raised when RDKit fails to kekulize during Molecule Creation"
+from molli.external import RDKitException, RDKitKekulizationException
 
 def _rd_problems(m: ml.Molecule, rdmol: PropertyMol, ext:str, raise_kekulize=True) -> PropertyMol:
     '''Checks for problems in created RDKit mol object. Adds "KekulizeException" if this problem is detected.
@@ -95,7 +89,7 @@ def _rd_problems(m: ml.Molecule, rdmol: PropertyMol, ext:str, raise_kekulize=Tru
         
         else:
             if raise_kekulize:
-                raise RDKitException(f'{m.name} is failing to kekulize with {ext} parsing')
+                raise RDKitKekulizationException(f'{m.name} is failing to kekulize with {ext} parsing')
             else:
                 rdmol.SetProp(problems[0], "1")
 

--- a/molli/external/rdkit.py
+++ b/molli/external/rdkit.py
@@ -19,7 +19,7 @@
 
 
 """
-# `molli.external._rdkit`
+# `molli.external.rdkit`
 This module defines necessary functions (albeit not a complete set) to interface with RDKit.
 """
 

--- a/molli_test/test_external_rdkit.py
+++ b/molli_test/test_external_rdkit.py
@@ -49,7 +49,7 @@ class RDKitTC(ut.TestCase):
             structs = ml.Structure.yield_from_mol2(f)
             for s in structs:
                 ml_mol = ml.Molecule(s, name=s.name)
-                #Not every Molecule is expected to work, it should either return an RDKit Exception
+                #Not every Molecule is expected to work, it should either return an RDKit Exception or PropertyMol
                 try:
                     rdmol = mrd.to_rdmol(ml_mol,via='sdf', remove_hs=True)
                     self.assertIsInstance(rdmol, PropertyMol)
@@ -143,7 +143,7 @@ class RDKitTC(ut.TestCase):
             structs = ml.Structure.yield_from_mol2(f)
             for s in structs:
                 ml_mol = ml.Molecule(s, name=s.name)
-                #Not every molecule is readable within the ZincDB, this is just testing for molecules that are
+                #Not every molecule is readable within the ZincDB, this is just testing molecules
                 try:
                     rdmol = mrd.to_rdmol(ml_mol,via='sdf', remove_hs=False)
                 except:

--- a/molli_test/test_external_rdkit.py
+++ b/molli_test/test_external_rdkit.py
@@ -29,7 +29,7 @@ import unittest as ut
 import numpy as np
 import molli as ml
 import importlib.util
-from molli.external.rdkit import RDKitException, RDKitKekulizationException
+from molli.external import RDKitException, RDKitKekulizationException
 
 def is_package_installed(pkg_name):
     return importlib.util.find_spec(pkg_name) is not None

--- a/molli_test/test_external_rdkit.py
+++ b/molli_test/test_external_rdkit.py
@@ -41,67 +41,144 @@ class RDKitTC(ut.TestCase):
     @ut.skipUnless(is_package_installed("rdkit"), "RDKit is not installed")
     @ut.skipUnless(is_package_installed("IPython"), "IPython is not installed")
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
-    def test_create_rdkit_mol(self):
+    def test_to_rdmol_zincdb(self):
         from rdkit.Chem.PropertyMol import PropertyMol
         from molli.external import _rdkit as mrd
 
         with ml.files.zincdb_fda_mol2.open() as f:
             structs = ml.Structure.yield_from_mol2(f)
             for s in structs:
-                molli_mol = ml.Molecule(s, name=s.name)
-                molli_mol_rdmol_dict = mrd.create_rdkit_mol(molli_mol)
-                self.assertIsInstance(molli_mol_rdmol_dict[molli_mol], PropertyMol)
+                ml_mol = ml.Molecule(s, name=s.name)
+                rdmol = mrd.to_rdmol(ml_mol,via='sdf', remove_hs=True)
+                #Not every Molecule is expected to work, it should either return a PropertyMol or tuple of (name,Exception)
+                self.assertIsInstance(rdmol, (PropertyMol,tuple))
 
     @ut.skipUnless(is_package_installed("rdkit"), "RDKit is not installed")
     @ut.skipUnless(is_package_installed("IPython"), "IPython is not installed")
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
-    def test_molli_mol_reorder(self):
+    def test_to_rdmol(self):
+        from rdkit.Chem.PropertyMol import PropertyMol
+        from molli.external import _rdkit as mrd
+
+        mlmol = ml.Molecule.load_mol2(ml.files.dendrobine_mol2, name="dendrobine")
+
+        mlmol.attrib['_MolTest'] = 1
+        for a in mlmol.atoms:
+            a.attrib['_AtomTest'] = 1
+
+        #Mol2 Test Keep Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='mol2', remove_hs=False, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertTrue(a.HasProp('_AtomTest'))
+        #Mol2 Test Remove Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='mol2', remove_hs=True, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertFalse(a.HasProp('_AtomTest'))
+
+        #XYZ Test Keep Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='xyz', remove_hs=False, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertTrue(a.HasProp('_AtomTest'))
+        #XYZ Test Remove Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='xyz', remove_hs=True, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertFalse(a.HasProp('_AtomTest'))
+
+        #MOL/SDF Test Keep Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='mol', remove_hs=False, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertTrue(a.HasProp('_AtomTest'))
+        #MOL/SDF Test Remove Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='mol', remove_hs=True, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertFalse(a.HasProp('_AtomTest'))
+
+        #PDB Test Keep Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='pdb', remove_hs=False, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertTrue(a.HasProp('_AtomTest'))
+        #PDB Test Remove Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='pdb', remove_hs=True, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+
+        #SMILES Test Keep Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='smi', remove_hs=False, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        #This one does not maintain the order, so it should be False
+        for a in rdmol.GetAtoms():
+            self.assertFalse(a.HasProp('_AtomTest'))
+        #SMILES Test Remove Hydrogens
+        rdmol = mrd.to_rdmol(mlmol,via='smi', remove_hs=True, set_atts=True)
+        self.assertIsInstance(rdmol, PropertyMol)
+        self.assertTrue(rdmol.HasProp('_MolTest'))
+        for a in rdmol.GetAtoms():
+            self.assertFalse(a.HasProp('_AtomTest'))
+
+    @ut.skipUnless(is_package_installed("rdkit"), "RDKit is not installed")
+    @ut.skipUnless(is_package_installed("IPython"), "IPython is not installed")
+    @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
+    def test_ml_mol_reorder(self):
         from rdkit.Chem.PropertyMol import PropertyMol
         from molli.external import _rdkit as mrd
 
         with ml.files.zincdb_fda_mol2.open() as f:
             structs = ml.Structure.yield_from_mol2(f)
             for s in structs:
-                molli_mol = ml.Molecule(s, name=s.name)
-                molli_mol_rdmol_dict = mrd.create_rdkit_mol(molli_mol)
-                rd_can_mol, atom_reorder, bond_reorder = mrd.can_mol_order(
-                    molli_mol_rdmol_dict[molli_mol]
-                )
-                molli_can_rdkit_dict = mrd.reorder_molecule(
-                    molli_mol,
-                    can_rdkit_mol_w_h=rd_can_mol,
-                    can_atom_reorder=atom_reorder,
-                    can_bond_reorder=bond_reorder,
-                )
-                for molli_mol, rdkit_mol in molli_can_rdkit_dict.items():
-                    can_rdkit_atom_elem = np.array(
-                        [x.GetSymbol() for x in rdkit_mol.GetAtoms()]
+                ml_mol = ml.Molecule(s, name=s.name)
+                rdmol = mrd.to_rdmol(ml_mol,via='sdf', remove_hs=False)
+                if isinstance(rdmol, PropertyMol):
+                    rd_can_mol, atom_reorder, bond_reorder = mrd.can_mol_order(
+                        rdmol
                     )
-                    new_molli_elem = np.array(
-                        [atom.element.symbol for atom in molli_mol.atoms]
+                    molli_can_rdkit_dict = mrd.reorder_molecule(
+                        ml_mol,
+                        can_rdmol_w_h=rd_can_mol,
+                        can_atom_reorder=atom_reorder,
+                        can_bond_reorder=bond_reorder,
                     )
-                    np.testing.assert_array_equal(can_rdkit_atom_elem, new_molli_elem)
+                    for ml_mol, rdkit_mol in molli_can_rdkit_dict.items():
+                        can_rdkit_atom_elem = np.array(
+                            [x.GetSymbol() for x in rdkit_mol.GetAtoms()]
+                        )
+                        new_molli_elem = np.array(
+                            [atom.element.symbol for atom in ml_mol.atoms]
+                        )
+                        np.testing.assert_array_equal(can_rdkit_atom_elem, new_molli_elem)
 
     @ut.skipUnless(is_package_installed("rdkit"), "RDKit is not installed")
     @ut.skipUnless(is_package_installed("IPython"), "IPython is not installed")
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
-    def test_rdkit_atom_filter(self):
-        from rdkit.Chem.PropertyMol import PropertyMol
+    def test_atom_filter(self):
         from molli.external import _rdkit as mrd
 
         m1 = ml.Molecule.load_mol2(ml.files.dendrobine_mol2, name="dendrobine")
 
-        molli_rdkit_dict = mrd.create_rdkit_mol(m1)
-        af_mol = mrd.rdkit_atom_filter(molli_rdkit_dict[m1])
+        rdmol = mrd.to_rdmol(m1,via='sdf', remove_hs=False)
+        maf_mol = mrd.atom_filter(rdmol)
 
-        af_mol_sp2_bool = af_mol.sp2_type()
+        af_mol_sp2_bool = maf_mol.sp2_type()
         num_sp2_atoms = np.count_nonzero(af_mol_sp2_bool)
         self.assertEqual(num_sp2_atoms, 3)
 
-        af_mol_het_neighbors_2 = af_mol.het_neighbors_2()
+        af_mol_het_neighbors_2 = maf_mol.het_neighbors_2()
         num_het_neighbors_2 = np.count_nonzero(af_mol_het_neighbors_2)
         self.assertEqual(num_het_neighbors_2, 1)
 
-        af_mol_dual_bool = af_mol.sp2_type() & af_mol.het_neighbors_2()
+        af_mol_dual_bool = maf_mol.sp2_type() & maf_mol.het_neighbors_2()
         num_af_mol_dual_bool = np.count_nonzero(af_mol_dual_bool)
         self.assertEqual(num_af_mol_dual_bool, 1)

--- a/molli_test/test_external_rdkit.py
+++ b/molli_test/test_external_rdkit.py
@@ -29,7 +29,7 @@ import unittest as ut
 import numpy as np
 import molli as ml
 import importlib.util
-from molli.external._rdkit import RDKitException, RDKitKekulizationException
+from molli.external.rdkit import RDKitException, RDKitKekulizationException
 
 def is_package_installed(pkg_name):
     return importlib.util.find_spec(pkg_name) is not None
@@ -43,7 +43,7 @@ class RDKitTC(ut.TestCase):
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
     def test_to_rdmol_zincdb(self):
         from rdkit.Chem.PropertyMol import PropertyMol
-        from molli.external import _rdkit as mrd
+        from molli.external import rdkit as mrd
 
         with ml.files.zincdb_fda_mol2.open() as f:
             structs = ml.Structure.yield_from_mol2(f)
@@ -61,7 +61,7 @@ class RDKitTC(ut.TestCase):
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
     def test_to_rdmol(self):
         from rdkit.Chem.PropertyMol import PropertyMol
-        from molli.external import _rdkit as mrd
+        from molli.external import rdkit as mrd
 
         mlmol = ml.Molecule.load_mol2(ml.files.dendrobine_mol2, name="dendrobine")
 
@@ -137,7 +137,7 @@ class RDKitTC(ut.TestCase):
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
     def test_ml_mol_reorder(self):
         from rdkit.Chem.PropertyMol import PropertyMol
-        from molli.external import _rdkit as mrd
+        from molli.external import rdkit as mrd
 
         with ml.files.zincdb_fda_mol2.open() as f:
             structs = ml.Structure.yield_from_mol2(f)
@@ -174,7 +174,7 @@ class RDKitTC(ut.TestCase):
     @ut.skipUnless(is_package_installed("IPython"), "IPython is not installed")
     @ut.skipUnless(is_package_installed("openbabel"), "Openbabel is not installed")
     def test_atom_filter(self):
-        from molli.external import _rdkit as mrd
+        from molli.external import rdkit as mrd
 
         m1 = ml.Molecule.load_mol2(ml.files.dendrobine_mol2, name="dendrobine")
 


### PR DESCRIPTION
I have made some stark changes to the RDKit Driver:

- `to_rdmol` is now a function, this allows more flexibility in how one reads Molli objects into RDKit objects. This interfaces with `openbabel` to allow for reading with SDF, PDB, and SMILES file formats. The SMILES parser has a small check to see if atoms were shuffled, but this is not necessarily fully robust as this is only a comparison between elements, not exact atom instances. This has resulted in SDF parsing be the default which will utilize Openbabel. This function also allows the integration of attributes in the molecule, bonds, or atoms when creating the RDKit molecule. These are required to be converted to a string format.
- `rd_visualize` this is an updated version for visualization of already existing RDKit molecule objects. This allows highlighting of atoms or bonds if they have a unique property for recognition stored within them.
- `ml_rd_visualize` this is an updated version for visualization of Molli Molecules via RDKit. This allows highlighting of atoms or bonds if they have a unique property for recognition stored within them in the original Molli Molecule object.